### PR TITLE
Visual tweaks

### DIFF
--- a/DevCleaner/Model/XcodeFiles.swift
+++ b/DevCleaner/Model/XcodeFiles.swift
@@ -480,7 +480,7 @@ final public class XcodeFiles {
             // sort by version & build
             let projectArchiveEntries = archiveEntries.sorted { (lhs, rhs) -> Bool in
                 if lhs.version == rhs.version {
-                    return lhs.build > rhs.build
+					return lhs.build.localizedStandardCompare(rhs.build) == .orderedDescending
                 } else {
                     return lhs.version > rhs.version
                 }

--- a/DevCleaner/View Controllers/Main Window/Views/XcodeEntryCellView.swift
+++ b/DevCleaner/View Controllers/Main Window/Views/XcodeEntryCellView.swift
@@ -46,6 +46,7 @@ final class XcodeEntryCellView: NSTableCellView {
         self.checkBox.state = self.entrySelectionToControlState(xcodeEntry.selection)
         
         // label
+		self.textField?.font = NSFont.monospacedDigitSystemFont(ofSize: self.textField?.font?.pointSize ?? 13, weight: .regular)
         self.textField?.attributedStringValue = self.attributedString(for: xcodeEntry)
         self.textField?.sizeToFit()
         


### PR DESCRIPTION
Hi!

I’ve made two changes which, I think, make for a better experience.

1. Changed the sorting of the build strings so if you have builds (1) through (11), they’ll be sorted (11), (10), (9), ..., (1) instead of (9), (8), ..., (11), (10), (1).
2. Used monospaced digits so the text in the rows aligns better.

**Before:**
![Screenshot 2019-06-26 at 10 21 26](https://user-images.githubusercontent.com/9286345/60162211-b9bbe980-9801-11e9-9768-2767df2a51d4.png)

**After:**
![Screenshot 2019-06-26 at 10 22 37](https://user-images.githubusercontent.com/9286345/60162212-ba548000-9801-11e9-8e38-e76e5db626d5.png)

