### PR TITLE
Fixes memory leak in md5 and refactors

### DIFF
--- a/DevCleaner/Utilities/Extensions/String+MD5.swift
+++ b/DevCleaner/Utilities/Extensions/String+MD5.swift
@@ -31,14 +31,15 @@ extension String {
         
         CC_MD5(str!, strLen, result)
         
-        let hash = NSMutableString()
+        var hash = String()
+        hash.reserveCapacity(digestLength * 2)
         
         for i in 0..<digestLength {
-            hash.appendFormat("%02x", result[i])
+            hash += String(format:"%02x", result[i])
         }
         
         result.deallocate()
         
-        return hash as String
+        return hash
     }
 }

--- a/DevCleaner/Utilities/Extensions/String+MD5.swift
+++ b/DevCleaner/Utilities/Extensions/String+MD5.swift
@@ -28,6 +28,7 @@ extension String {
         let strLen = CUnsignedInt(self.lengthOfBytes(using: .utf8))
         let digestLength = Int(CC_MD5_DIGEST_LENGTH)
         let result = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: digestLength)
+        defer { result.deallocate() }
         
         CC_MD5(str!, strLen, result)
         
@@ -37,8 +38,6 @@ extension String {
         for i in 0..<digestLength {
             hash += String(format:"%02x", result[i])
         }
-        
-        result.deallocate()
         
         return hash
     }

--- a/DevCleaner/Utilities/Extensions/String+MD5.swift
+++ b/DevCleaner/Utilities/Extensions/String+MD5.swift
@@ -37,7 +37,7 @@ extension String {
             hash.appendFormat("%02x", result[i])
         }
         
-        result.deinitialize(count: 1)
+        result.deallocate()
         
         return hash as String
     }

--- a/DevCleaner/Utilities/Extensions/String+MD5.swift
+++ b/DevCleaner/Utilities/Extensions/String+MD5.swift
@@ -24,8 +24,8 @@ import CommonCrypto
 
 extension String {
     public var md5: String {
-        let str = self.cString(using: String.Encoding.utf8)
-        let strLen = CUnsignedInt(self.lengthOfBytes(using: String.Encoding.utf8))
+        let str = self.cString(using: .utf8)
+        let strLen = CUnsignedInt(self.lengthOfBytes(using: .utf8))
         let digestLength = Int(CC_MD5_DIGEST_LENGTH)
         let result = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: digestLength)
         


### PR DESCRIPTION
Fixes memory leak adding missing call to `deallocate()` instead of wrong `deinitialize(count: 1)`.
Gets rid of `NSMutableString` along with overhead with bridging it to `String`.