### PR TITLE
Always run as CLI when running from `dev-cleaner.sh` script

### DIFF
--- a/DevCleaner/Resources/dev-cleaner.sh
+++ b/DevCleaner/Resources/dev-cleaner.sh
@@ -24,7 +24,7 @@
 DEV_CLEANER_PATH=$(defaults read com.oneminutegames.XcodeCleaner DCAppFolder)
 
 if [ -d $DEV_CLEANER_PATH ]; then
-    "$DEV_CLEANER_PATH/Contents/MacOS/DevCleaner" "$@"
+    DEV_CLEANER_HEADLESS=1 "$DEV_CLEANER_PATH/Contents/MacOS/DevCleaner" "$@"
 else
     echo "DevCleaner cannot be found, check if you haven't uninstalled it or moved. Path where it was expected: $DEV_CLEANER_PATH"
 fi


### PR DESCRIPTION
Hi!

This is a super quick proof of concept implementation to solve https://github.com/vashpan/xcode-dev-cleaner/issues/27.

This is by no means the correct approach, or the final code, but rather an implementation that I hope we can comment on and update from some discussion.

If you have any issues, comments, ideas, etc. I'd love to hear them.

But also, perhaps you're happy with this implementation and it's good to merge.

Would love to hear your thoughts and make any changes based on your judgement.

Thanks!