### PR TITLE
support multiline selection and toggling

### DIFF
--- a/DevCleaner/View Controllers/Main Window/Base.lproj/Main.storyboard
+++ b/DevCleaner/View Controllers/Main Window/Base.lproj/Main.storyboard
@@ -226,7 +226,7 @@ DQ
                                             <rect key="frame" x="1" y="1" width="454" height="398"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" rowSizeStyle="automatic" headerView="v75-Hl-aeO" viewBased="YES" indentationPerLevel="18" outlineTableColumn="WoQ-aT-xsT" id="xU2-il-hl0">
+                                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" rowSizeStyle="automatic" headerView="v75-Hl-aeO" viewBased="YES" indentationPerLevel="18" outlineTableColumn="WoQ-aT-xsT" id="xU2-il-hl0">
                                                     <rect key="frame" x="0.0" y="0.0" width="604" height="375"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="2" height="3"/>


### PR DESCRIPTION
Outline view supports multiple selection and when toggling selection with space entire selection is toggled and showInFinder includes entire selection.

This is especially useful when you have a lot of archives and want to clean the oldest ones.

Perhaps clicking a checkbox should toggle the entire selection but this felt a little weird. 
Only toggling the checkbox you click also feels a bit weird.

https://github.com/user-attachments/assets/5aef32db-b39d-4c40-a20a-8e0cd5d911ec

