### PR TITLE
Model: Added the Apple Watch Series 10 to device support entries

### DIFF
--- a/DevCleaner/Model/Entries/DeviceSupportFileEntry.swift
+++ b/DevCleaner/Model/Entries/DeviceSupportFileEntry.swift
@@ -356,7 +356,9 @@ public final class DeviceSupportFileEntry: XcodeFileEntry {
                 return "Apple Watch Series 9"
             case "Watch7,5":
                 return "Apple Watch Ultra 2"
-                
+            case "Watch7,8", "Watch7,9", "Watch7,10", "Watch7,11":
+                return "Apple Watch Series 10"
+            
             // Apple TV
             case "AppleTV5,3":
                 return "Apple TV"


### PR DESCRIPTION
I was just using DevCleaner and I noticed my Series 10 was displaying as `Watch7,9`, so I fixed it.

Before:
![Screenshot 2024-11-20 at 12 45 25](https://github.com/user-attachments/assets/38568ec3-1f8c-485c-907d-4c5b9d9d39df)

After:
![Screenshot 2024-11-20 at 12 42 04](https://github.com/user-attachments/assets/3d3ac44c-5848-4c02-a606-eaa7c91e3a22)
