### PR TITLE
Model: Group unrecognized Derived Data folders under "Other" node

### DIFF
--- a/DevCleaner/Model/XcodeFiles.swift
+++ b/DevCleaner/Model/XcodeFiles.swift
@@ -264,13 +264,14 @@ final public class XcodeFiles {
                                       selected: false)
     }
     
+    private func derivedDataFolderName(from url: URL) -> String {
+        let splitted = url.lastPathComponent.split(separator: "-", omittingEmptySubsequences: true).dropLast()
+        return splitted.joined(separator: "-").replacingOccurrences(of: "_", with: " ")
+    }
+
     private func derivedDataEntry(from location: URL) -> DerivedDataFileEntry? {
-        // drop last part that's the kind of id of a project
-        let splitted = location.lastPathComponent.split(separator: "-", omittingEmptySubsequences: true).dropLast()
-        
-        // create project name
-        let name = splitted.joined(separator: "-").replacingOccurrences(of: "_", with: " ") // replace all dashes with spaces
-        
+        let name = self.derivedDataFolderName(from: location)
+
         // find project folder path
         let infoPath = location.appendingPathComponent("info.plist")
         
@@ -615,6 +616,7 @@ final public class XcodeFiles {
         
         // scan for derived data projects
         var results: [XcodeFileEntry] = []
+        var otherFolders: [URL] = []
         for derivedDataLocation in derivedDataLocations {
             if let projectsFolders = try? FileManager.default.contentsOfDirectory(at: derivedDataLocation, includingPropertiesForKeys: nil, options: Self.scanFileEnumerationOptions) {
                 for projectFolder in projectsFolders {
@@ -622,25 +624,39 @@ final public class XcodeFiles {
                     if projectFolder.lastPathComponent == "ModuleCache" {
                         continue
                     }
-                    
+
                     if let projectEntry = self.derivedDataEntry(from: projectFolder) {
                         projectEntry.addPath(path: projectFolder)
-                        
                         results.append(projectEntry)
+                    } else {
+                        otherFolders.append(projectFolder)
                     }
                 }
             }
         }
-        
+
         // sort
         for entry in results {
             entry.recalculateSize()
         }
-        
+
         results = results.sorted { lhs, rhs in
             return lhs.size > rhs.size
         }
-        
+
+        // group unrecognized folders under an "Other" node, appended after the sorted results
+        if !otherFolders.isEmpty {
+            let otherEntry = XcodeFileEntry(label: "Other", extraInfo: "", icon: .system(name: NSImage.folderName), selected: false)
+            for folder in otherFolders {
+                let name = self.derivedDataFolderName(from: folder)
+                let childEntry = DerivedDataFileEntry(projectName: name, pathUrl: folder, selected: false)
+                childEntry.addPath(path: folder)
+                otherEntry.addChild(item: childEntry)
+            }
+            otherEntry.recalculateSize()
+            results.append(otherEntry)
+        }
+
         return results
     }
     

--- a/DevCleaner/Resources/Manual/manual.html
+++ b/DevCleaner/Resources/Manual/manual.html
@@ -36,6 +36,7 @@
         <h4>Derived Data</h4>
         <p>When you develop your app, Xcode caches your symbols, dependencies, logs, text - all to develop fast and to keep code completion working. Unfortunately this data tend to take a lot of space, especially for big projects. Also, they're not deleted automatically. This may be especially problematic if you open a lot of various projects.</p>
         <p>Removing derived data is not harmful as Xcode can recreate them when you open project again. Although it's not recommended for projects that you work on often. For this reason nothing is selected by default.</p>
+        <p>Some folders inside <code>DerivedData</code> may not be recognized as a specific project — for example orphaned caches left behind after a project was deleted or renamed, or entries that were corrupted and are missing their metadata. These folders are grouped under an <b>Other</b> node at the bottom of the Derived Data list so you can inspect and clean them too.</p>
         
         <h4>Documentation Cache</h4>
         <p>Modern Xcodes are caching documentation that is accessed via the web. Unfortunately older caches are not cleaned up by Xcode and significant


### PR DESCRIPTION
## Summary

- Folders in `DerivedData` that lack an `info.plist` (orphaned caches, corrupted entries) were previously silently skipped and never shown in the UI
- They are now collected and displayed as children of an \"Other\" entry at the bottom of the Derived Data tree
- Extracted `derivedDataFolderName(from:)` as a shared private helper to avoid duplicating the hash-stripping logic

## Test plan

- [ ] Build succeeds with no warnings
- [ ] Normal scan with only well-formed project folders: \"Other\" node does not appear (no regression)
- [ ] Create a dummy folder without `info.plist` in `~/Library/Developer/Xcode/DerivedData` (e.g. `TestOrphan-abc123`), rescan: \"Other\" node appears at the bottom of Derived Data, expandable to show the folder with its size
- [ ] Select the \"Other\" entry or individual children and verify the selected-bytes counter updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)